### PR TITLE
Fix typo in the title of the dataset in CFF

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@
 # Visit https://bit.ly/cffinit to generate yours today!
 
 cff-version: 1.2.0
-title: Princetion Geniza Project datasets
+title: Princeton Geniza Project datasets
 message: >-
   If you use this dataset, please cite it using the metadata
   from this file.


### PR DESCRIPTION
There is a typo in the dataset title in the CFF file (🤦‍♀️ ) — and also on Zenodo. 

This PR fixes the CFF; please manually correct the Zenodo record.