### PR TITLE
Correct numbers in change log; adjust formatting/order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,27 +4,28 @@
 
 ### Data changes
 
-- Total 41230 documents (+6036)
-- Total 36171 fragments (+563)
-- Total 729 sources (+50)
-- Total 24403 footnotes (+841)
-- Total 1772 people (+439)
+- Total 35,855 documents (+661)
+- Total 36,172 fragments (+564)
+- Total 712 sources (+33)
+- Total 24,412 footnotes (+850)
+- Total 1,802 people (+469)
 - Total 486 places (+77)
 
 ### Structural changes
 
-- Renaming the attribute *occasional_trips_to* to *traveled_to* in people
-- Renaming the attribute *old_shelfmark* to *shelfmark_historic* in fragment
-- Adding a new attribute to footnotes_source: *source_slug*
-- Adding 3 new attributes to fragment: *provenance*, *provenance_display*, and *material_support*
-- Adding 2 new attributes to places: *is_region* and *geographic_area*
-- Adding 2 new attributes to sources: *citation* and *slug*
+- fragments:
+   - renamed `old_shelfmark` to `shelfmark_historic`
+   - 3 new fields: `provenance`, `provenance_display`, `material_support`
+- sources: 2 new fields: `citation`, `slug`
+- footnotes: 1 new field `source_slug`
+- people: renamed `occasional_trips_to` to `traveled_to`
+- places: 2 new fields: `is_region`, `geographic_area`
 
 ## Version 1.0, July 2025
 
-- Total 35194 documents 
-- Total 35608 fragments 
-- Total 679 sources 
-- Total 23562 footnotes 
-- Total 1333 people 
-- Total 409 places 
+- Total 35,194 documents
+- Total 35,608 fragments
+- Total 679 sources
+- Total 23,562 footnotes
+- Total 1,333 people
+- Total 409 places

--- a/pgp_datapackage.json
+++ b/pgp_datapackage.json
@@ -19,7 +19,6 @@
       "mediatype": "text/csv",
       "encoding": "utf-8-sig",
       "fields": 30,
-      "rows": 35855,
       "schema": {
         "fields": [
           {
@@ -272,7 +271,6 @@
       "mediatype": "text/csv",
       "encoding": "utf-8-sig",
       "fields": 16,
-      "rows": 36172,
       "schema": {
         "fields": [
           {
@@ -390,7 +388,6 @@
       "mediatype": "text/csv",
       "encoding": "utf-8-sig",
       "fields": 18,
-      "rows": 712,
       "schema": {
         "fields": [
           {
@@ -518,7 +515,6 @@
       "mediatype": "text/csv",
       "encoding": "utf-8-sig",
       "fields": 10,
-      "rows": 24412,
       "schema": {
         "fields": [
           {
@@ -613,7 +609,6 @@
       "mediatype": "text/csv",
       "encoding": "utf-8-sig",
       "fields": 14,
-      "rows": 1802,
       "schema": {
         "fields": [
           {
@@ -713,7 +708,6 @@
       "mediatype": "text/csv",
       "encoding": "utf-8-sig",
       "fields": 10,
-      "rows": 486,
       "schema": {
         "fields": [
           {


### PR DESCRIPTION
I assumed when you corrected the numbers that you would fix the change log, but I forgot to confirm on my last review.

This PR corrects the numbers in the change log so they accurately reflect the data.

I've also reformatted the list of structural changes to make it more scannable; resources/files are listed first, and in the same logical order we use elsewhere.

Updated: removed row counts from data package for validation against current data.